### PR TITLE
Support multiple county filter

### DIFF
--- a/candidates/filters.py
+++ b/candidates/filters.py
@@ -1,0 +1,17 @@
+from django_filters import rest_framework as filters
+from .models import Terms
+
+class TermsFilter(filters.FilterSet):
+    county = filters.CharFilter(method='filter_county')
+
+    def filter_county(self, qs, name, value):
+        if not value:
+            return qs
+            
+        filter_value = value.lstrip('[').rstrip(']').split(',')
+        filter_value = [x.strip('"').strip() for x in filter_value]
+        return qs.filter(**{name+'__in':filter_value})
+
+    class Meta:
+        model = Terms
+        fields = ('election_year', 'type', 'name', 'gender', 'party', 'constituency', 'county', 'district', 'votes', 'elected', 'occupy')

--- a/candidates/views.py
+++ b/candidates/views.py
@@ -3,8 +3,10 @@ from .models import Terms
 from .serializers import CandidatesTermsSerializer
 from django.db.models import Prefetch
 from boards.models import Boards
+from .filters import TermsFilter
 
 class CandidatesTermsViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Terms.objects.all().select_related('candidate').prefetch_related(Prefetch('boards', queryset=Boards.objects.order_by('-uploaded_at')))
     serializer_class = CandidatesTermsSerializer
     filter_fields = ('election_year', 'type', 'name', 'gender', 'party', 'constituency', 'county', 'district', 'votes', 'elected', 'occupy')
+    filterset_class = TermsFilter


### PR DESCRIPTION
## API
**route:** `/api/candidates_terms`

### Usage
Other filter remain the same as before. `county` filter now is an array in string format. The parameter should be wrap in square bracket set `[ ]`. Each element between the bracket should be the name string of each desired counties. The name strings could be double quoted(`" "`) or no-quoted, but not support single quote(`' '`). The name strings could contain blank, but not recommended.

### Example
#### Work
```bash
/api/candidates_terms?county=["臺北市","桃園市","高雄市"]
/api/candidates_terms?county=[臺北市,桃園市,高雄市]
/api/candidates_terms?county=["臺北市","桃園市","    高雄市"]
```

#### Not work
```bash
/api/candidates_terms?county=['臺北市','桃園市','高雄市']
```
**Not working example would not return error, instead it gives empty repsonse.**

This fix #19 