### PR TITLE
Integrated drone release procedure in master branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,8 +14,7 @@ pipeline:
     when:
       event: [push]
       branch: [master, dev]
-  
-  
+
   get_dev_config:
     image: gcr.io/mirrormedia-1470651750304/drone-cloud-sdk:latest
     secrets: [google_credentials]
@@ -32,7 +31,8 @@ pipeline:
     commands:
     - gcloud source repos clone default ../default
     - cp ../default/election-boards/production/production.py ./election_boards/settings/production.py
-    - cp ../default/election-boards/production/uwsgi.ini ./uwsgi.ini 
+    - cp ../default/election-boards/production/uwsgi.ini ./uwsgi.ini
+    - cp ../default/election-boards/production/.kube.yml ./.kube.yml
     when:
       event: [push]
       branch: master
@@ -69,6 +69,27 @@ pipeline:
       event: [push]
       branch: dev
 
+  deploy_prod:
+    image: nytimes/drone-gke:develop
+    zone: asia-east1-a
+    cluster: prod-readr
+    namespace: default
+    # For debugging
+    dry_run: false
+    verbose: true
+    secrets:
+      - source: google_credentials
+        target: token
+    vars:
+      image: gcr.io/mirrormedia-1470651750304/${DRONE_REPO_NAME}:${DRONE_COMMIT_AUTHOR}_${DRONE_COMMIT_BRANCH}_${DRONE_BUILD_NUMBER}
+      app: election-boards
+      tier: backend
+      serviceName: election-boards
+      deployName: election-boards
+    when:
+      event: [push]
+      branch: master
+
   finish_slack:
     image: plugins/slack
     channel: jenkins
@@ -82,7 +103,7 @@ pipeline:
     template: >
       {{#success build.status}}
         Build<${DRONE_BUILD_LINK}|#{{build.number}}> *success* ${DRONE_REPO_NAME}:${DRONE_COMMIT_AUTHOR}_${DRONE_COMMIT_BRANCH}_${DRONE_BUILD_NUMBER} was well served.
-        Check out our new <https://gcr.io/mirrormedia-1470651750304/election-boards|rest>
+        Check on our <https://www.readr.tw|site>
       {{else}}
         Houston, we have a problem. Build <${DRONE_BUILD_LINK}|#{{build.number}}> failed. Fix me please, {{build.author}}
-      {{/success}}
+      {{/success}


### PR DESCRIPTION
Experiementing merge driven release flow in Github. Election-boards could be built and deployed to production once it's merge into `master` branch.