### PR TITLE
GET single verify board API changes

### DIFF
--- a/boards/filters.py
+++ b/boards/filters.py
@@ -23,3 +23,10 @@ class BoardsFilter(filters.FilterSet):
     class Meta:
         model = Boards
         fields = ('uploaded_by','coordinates')
+
+class SingleCheckFilter(filters.FilterSet):
+    uploaded_by = filters.UUIDFilter(field_name='uploaded_by', lookup_expr='exact', exclude=True)
+
+    class Meta:
+        model = Boards
+        fields = ('uploaded_by',)

--- a/boards/filters.py
+++ b/boards/filters.py
@@ -26,7 +26,8 @@ class BoardsFilter(filters.FilterSet):
 
 class SingleCheckFilter(filters.FilterSet):
     uploaded_by = filters.UUIDFilter(field_name='uploaded_by', lookup_expr='exact', exclude=True)
+    skip_board = filters.NumberFilter(field_name='id', lookup_expr='gt')
 
     class Meta:
         model = Boards
-        fields = ('uploaded_by',)
+        fields = ('uploaded_by','skip_board')

--- a/boards/serializers.py
+++ b/boards/serializers.py
@@ -111,4 +111,12 @@ class CheckMultiBoardsDeserializer(serializers.Serializer):
                 check.save()
 
         return validated_data
+
+class GetSingleCheckBoardSerializer(serializers.ModelSerializer):
+
+    # slogan = serializers.CharField()
+
+    class Meta:
+        model = Boards
+        fields = ('id', 'candidates', 'image', 'verified_amount', 'uploaded_by')
     

--- a/boards/views.py
+++ b/boards/views.py
@@ -51,8 +51,12 @@ class CheckView(mixins.CreateModelMixin,
     @swagger_auto_schema(manual_parameters=[openapi.Parameter('uploaded_by', openapi.IN_QUERY, description="exclude boards uploaded by user[uuid]", type=openapi.TYPE_STRING)])
     def list(self, request):
         queryset = self.filter_queryset(self.get_queryset())
-        # Only return a board
-        serializer = self.get_serializer(queryset[0])
+        # If nothing selected(reach the end), sql query again and start from beginning
+        if queryset.count() == 0:
+            serializer = self.get_serializer(self.get_queryset()[0])
+        else:
+            # only return the first one
+            serializer = self.get_serializer(queryset[0])
         return response.Response(serializer.data)
 
     def get_serializer_class(self):


### PR DESCRIPTION
## Route
`/api/verify/board`

## Changelog
### Response
Response limited to necessary fields: `candidates`, `image`, `verified_amount`, and `uploaded_by`
```json
{
    "id": 0,
    "candidates": [
      0
    ],
    "image": "string",
    "verified_amount": 0,
    "uploaded_by": "string"
}
```

### Skip filter
Provided `skip_board` parameter to filter unwanted boards. Fill in the board id and the corresponding SQL query will return result with next closest id. If there are no result to return, server will start from beginning(hence made an extra sql query)

**usage:** `GET /api/verify/board?skip_board=36`
Assuming the id of next valid board is 38, it will return board 38. If board 36 is the last board, the result will be the first board server ever returned.

### Note
In this version, original `uploaded_by` filter, implemented in view's `get_queryset()` is fully switch to using `django-filter`

This partially implement #17 