### PR TITLE
GET multiple boards, GET single verify board API changes

### DIFF
--- a/boards/filters.py
+++ b/boards/filters.py
@@ -7,6 +7,7 @@ from django.contrib.gis.measure import D
 
 class BoardsFilter(filters.FilterSet):
     uploaded_by = filters.UUIDFilter(field_name='uploaded_by', lookup_expr='exact')
+    verified_amount = filters.NumberFilter(field_name='verified_amount', lookup_expr='gte')
     coordinates = filters.CharFilter(method='filter_coordinates')
 
     def filter_coordinates(self, qs, name, value):
@@ -22,7 +23,7 @@ class BoardsFilter(filters.FilterSet):
         
     class Meta:
         model = Boards
-        fields = ('uploaded_by','coordinates')
+        fields = ('uploaded_by','coordinates', 'verified_amount')
 
 class SingleCheckFilter(filters.FilterSet):
     uploaded_by = filters.UUIDFilter(field_name='uploaded_by', lookup_expr='exact', exclude=True)

--- a/boards/urls.py
+++ b/boards/urls.py
@@ -6,5 +6,6 @@ app_name = 'boards'
 urlpatterns = [
     path('boards/', BoardsView.as_view({'get':'list', 'post':'create'})),
     path('verify/board', CheckView.as_view({'get':'list', 'post':'create'})),
+    path('verify/board/<int:pk>', CheckView.as_view({'get':'retrieve'})),
     path('verify/boards', CheckBoardsViewSet.as_view({'post':'create'})),
 ]

--- a/boards/views.py
+++ b/boards/views.py
@@ -41,6 +41,7 @@ class BoardsView(viewsets.ModelViewSet):
 # class CheckView(viewsets.ModelViewSet):
 class CheckView(mixins.CreateModelMixin,
                 mixins.ListModelMixin,
+                mixins.RetrieveModelMixin,
                 viewsets.GenericViewSet):
 
     queryset = Boards.objects.order_by('verified_amount', 'uploaded_at')
@@ -60,11 +61,9 @@ class CheckView(mixins.CreateModelMixin,
         return response.Response(serializer.data)
 
     def get_serializer_class(self):
-        if self.action == 'list':
-            return GetSingleCheckBoardSerializer
-        elif self.action == 'create':
+        if self.action == 'create':
             return CheckBoardDeserializer
-        return BoardsGetSerializer
+        return GetSingleCheckBoardSerializer
 
 class CheckBoardsViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
     permission_classes = []

--- a/boards/views.py
+++ b/boards/views.py
@@ -27,7 +27,8 @@ class BoardsView(viewsets.ModelViewSet):
     @swagger_auto_schema(manual_parameters=[
         openapi.Parameter('coordinates', openapi.IN_QUERY, description="Coordinates format in (latitude lontitude)", type=openapi.TYPE_STRING),
         openapi.Parameter('radius', openapi.IN_QUERY, description="Radius from coordinates, default to 100m", type=openapi.TYPE_INTEGER),
-        openapi.Parameter('uploaded_by', openapi.IN_QUERY, description="exclude boards uploaded by this user", type=openapi.TYPE_STRING)])
+        openapi.Parameter('uploaded_by', openapi.IN_QUERY, description="exclude boards uploaded by this user", type=openapi.TYPE_STRING),
+        openapi.Parameter('verified_amount', openapi.IN_QUERY, description="return boards with verified_amount greater than this", type=openapi.TYPE_INTEGER)])
     def list(self, request):
         return super(BoardsView, self).list(request)
 
@@ -49,7 +50,9 @@ class CheckView(mixins.CreateModelMixin,
     pagination_class = None
     filterset_class = SingleCheckFilter
 
-    @swagger_auto_schema(manual_parameters=[openapi.Parameter('uploaded_by', openapi.IN_QUERY, description="exclude boards uploaded by user[uuid]", type=openapi.TYPE_STRING)])
+    @swagger_auto_schema(manual_parameters=[
+        openapi.Parameter('uploaded_by', openapi.IN_QUERY, description="exclude boards uploaded by [uploaded_by]", type=openapi.TYPE_STRING),
+        openapi.Parameter('skip_board', openapi.IN_QUERY, description="Skip board with id prior to [skip_board]", type=openapi.TYPE_INTEGER)])
     def list(self, request):
         queryset = self.filter_queryset(self.get_queryset())
         # If nothing selected(reach the end), sql query again and start from beginning


### PR DESCRIPTION
## GET multiple boards
### Route
`/api/boards`

### Changelog

Multiple boards API now support query parameter `verified_amount`. Once denoted, e.g. `verified_amount=3`, the results will boards whose `verified_amount >= 3`

**usage:** `GET /api/boards?verified_amount=3`

This partially implement #15 

## GET single verify board
### Route
`/api/verify/board/<pk>`

### Changelog

`pk` is the `id` in boards response. Denote `pk` is the route, will return corresponding board.

**usage:** `GET /api/verify/board/6`
This will return board whose id is 6.

This partially implement #17 
