### PR TITLE
Included slogan field in GET single verify board

### DIFF
--- a/boards/serializers.py
+++ b/boards/serializers.py
@@ -114,9 +114,8 @@ class CheckMultiBoardsDeserializer(serializers.Serializer):
 
 class GetSingleCheckBoardSerializer(serializers.ModelSerializer):
 
-    # slogan = serializers.CharField()
+    slogan = serializers.CharField()
 
     class Meta:
         model = Boards
-        fields = ('id', 'candidates', 'image', 'verified_amount', 'uploaded_by')
-    
+        fields = ('id', 'candidates', 'image', 'verified_amount', 'uploaded_by', 'slogan')

--- a/boards/views.py
+++ b/boards/views.py
@@ -6,6 +6,8 @@ from .filters import BoardsFilter, SingleCheckFilter
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 
+from django.db.models import Max
+
 class BoardsPagination(PageNumberPagination):
     permission_classes = []
     """
@@ -64,6 +66,12 @@ class CheckView(mixins.CreateModelMixin,
             serializer = self.get_serializer(queryset[0])
         return response.Response(serializer.data)
 
+    def get_queryset(self):
+        qs = Boards.objects.order_by('verified_amount', 'uploaded_at')
+        if self.action == 'list' or self.action == 'retrieve':
+            qs = Boards.objects.annotate(slogan=Max('board_checks__slogan')).order_by('verified_amount', 'uploaded_at')
+        return qs
+            
     def get_serializer_class(self):
         if self.action == 'create':
             return CheckBoardDeserializer


### PR DESCRIPTION
## Route
`/api/verify/board`

## Changelog
response body change to 
```json
{
    "id": 0,
    "candidates": [
      0
    ],
    "image": "string",
    "verified_amount": 0,
    "uploaded_by": "string",
    "slogan": "string"
}
```

`slogan` will be the most common answers selected from verification history for each board.

This close #17 