### PR TITLE
Verify single board API modification

### DIFF
--- a/boards/filters.py
+++ b/boards/filters.py
@@ -1,5 +1,6 @@
 from django_filters import rest_framework as filters
 from .models import Boards
+from candidates.models import Terms
 import re
 from django.contrib.gis.geos import Point
 from django.contrib.gis.db.models.functions import Distance
@@ -12,6 +13,7 @@ class BoardsFilter(filters.FilterSet):
     verified_amount = filters.NumberFilter(field_name='verified_amount', lookup_expr='gte')
     not_board_amount = filters.NumberFilter(method='filter_not_board_amount')
     coordinates = filters.CharFilter(method='filter_coordinates')
+    candidates = filters.ModelChoiceFilter(queryset=Terms.objects.all())
 
     def filter_coordinates(self, qs, name, value):
         if not value:
@@ -32,7 +34,7 @@ class BoardsFilter(filters.FilterSet):
 
     class Meta:
         model = Boards
-        fields = ('uploaded_by','coordinates', 'verified_amount', 'not_board_amount')
+        fields = ('uploaded_by','coordinates', 'verified_amount', 'not_board_amount', 'candidates')
 
 class SingleCheckFilter(filters.FilterSet):
     uploaded_by = filters.UUIDFilter(field_name='uploaded_by', lookup_expr='exact', exclude=True)

--- a/boards/serializers.py
+++ b/boards/serializers.py
@@ -68,8 +68,8 @@ class CheckBoardDeserializer(serializers.ModelSerializer):
         check_candidates = [] 
         if 'candidates' in validated_data:
             check_candidates = validated_data.pop('candidates')
-            if len(check_candidates) <= 0:
-                raise serializers.ValidationError("candidats field presented but its length is 0")
+            # if len(check_candidates) <= 0:
+            #     raise serializers.ValidationError("candidats field presented but its length is 0")
         validated_data['type'] = 1
         check = Checks.objects.create(**validated_data)
 
@@ -115,6 +115,7 @@ class CheckMultiBoardsDeserializer(serializers.Serializer):
 class GetSingleCheckBoardSerializer(serializers.ModelSerializer):
 
     slogan = serializers.CharField()
+    candidates = BoardsTermsSerializer(many=True,read_only=True)
 
     class Meta:
         model = Boards


### PR DESCRIPTION
## Verify single board API
**route**: `/api/verify/board`

### Changelog
1. GET return full candidates info
2. POST allow empty candidates list

## Get multiple boards API
**route:** `/api/boards`

### Changelog
1. Support `candidates` filter to get boards from the same candidate if candidate id denoted.

**usage:** `/api/boards?candidate=34320`
`34320` is the candidate id. 

This close #15 