### PR TITLE
Provided verified_amount and not_board_amount filter 

### DIFF
--- a/candidates/filters.py
+++ b/candidates/filters.py
@@ -1,8 +1,12 @@
 from django_filters import rest_framework as filters
 from .models import Terms
+from boards.models import Boards
+from django.db.models import Prefetch, Q, Count, Subquery
 
 class TermsFilter(filters.FilterSet):
     county = filters.CharFilter(method='filter_county')
+    verified_amount = filters.NumberFilter(method='filter_verified_amount')
+    not_board_amount = filters.NumberFilter(method='filter_not_board_amount')
 
     def filter_county(self, qs, name, value):
         if not value:
@@ -11,6 +15,29 @@ class TermsFilter(filters.FilterSet):
         filter_value = value.lstrip('[').rstrip(']').split(',')
         filter_value = [x.strip('"').strip() for x in filter_value]
         return qs.filter(**{name+'__in':filter_value})
+
+    def filter_verified_amount(self, qs, name, verified_amount):
+        if not verified_amount:
+            return qs
+
+        not_board_amount = self.request.query_params.get('not_board_amount', None)
+        if not_board_amount is None:
+            not_board_amount = 2
+        boards = Boards.objects.annotate(not_board_amount=Count('board_checks', filter=Q(board_checks__type=2, board_checks__is_board=False))).filter(not_board_amount__lte=not_board_amount).order_by('-uploaded_at') 
+        qs = Terms.objects.select_related('candidate') \
+            .prefetch_related(Prefetch('boards', queryset=boards)) \
+            .annotate(verified_board_amount=Count('boards', filter=Q(boards__verified_amount__gte=verified_amount)))
+
+    def filter_not_board_amount(self, qs, name, not_board_amount):
+        if not not_board_amount:
+            return qs
+
+        verified_amount = self.request.query_params.get('verified_amount', None)
+        if verified_amount is None:
+            verified_amount = 3
+        return Terms.objects.select_related('candidate') \
+            .prefetch_related(Prefetch('boards', queryset=Boards.objects.annotate(not_board_amount=Count('board_checks', filter=Q(board_checks__type=2, board_checks__is_board=False))).filter(not_board_amount__lte=not_board_amount).order_by('-uploaded_at'))) \
+            .annotate(verified_board_amount=Count('boards', filter=Q(boards__verified_amount__gte=verified_amount)))
 
     class Meta:
         model = Terms

--- a/candidates/models.py
+++ b/candidates/models.py
@@ -54,5 +54,6 @@ class Terms(models.Model):
         unique_together = ("candidate", "election_year")
         index_together = ['election_year', 'county', 'constituency']
         ordering = ['county','type','id']
+    
     def __unicode__(self):
         return self.name

--- a/candidates/serializers.py
+++ b/candidates/serializers.py
@@ -10,9 +10,10 @@ class CandidatesSerializer(serializers.ModelSerializer):
 
 # special TermsSerializer for Boards
 class SingleBoardSerializer(serializers.ModelSerializer):
+    not_board_amount = serializers.IntegerField()
     class Meta:
         model = Boards
-        fields = ('image','coordinates','county','district','road','took_at','uploaded_at','uploaded_by','verified_amount')
+        fields = ('image','coordinates','county','district','road','took_at','uploaded_at','uploaded_by','verified_amount', 'not_board_amount')
 
     def to_representation(self, instance):
         location = instance.coordinates
@@ -23,18 +24,19 @@ class SingleBoardSerializer(serializers.ModelSerializer):
 
 class CandidatesTermsSerializer(serializers.HyperlinkedModelSerializer):
     boards = SingleBoardSerializer(many=True)
+    verified_board_amount = serializers.IntegerField()
+    unverified_board_amount = serializers.IntegerField(default=0) # Set default=0 to avoid empty models field problem
+
     class Meta:
         model = Terms
-        fields = ('id','uid', 'election_year', 'type', 'county', 'district', 'name', 'party', 'number', 'image','boards','constituency')
+        fields = ('id','uid', 'election_year', 'type', 'county', 'district', 'name', 'party', 'number', 'image', 'boards', 'constituency', 'verified_board_amount', 'unverified_board_amount')
     
     def to_representation(self, instance):
         ret = super(CandidatesTermsSerializer, self).to_representation(instance)
+        # Calculate unverified_board_amount from correct boards length and verified_board_amount
+        ret['unverified_board_amount'] = len(ret['boards']) - ret['verified_board_amount']
+        
         if len(ret['boards']) > 1:
             ret['boards'] = ret['boards'][0]
         return ret
-
-class g0vCandidatesTermsSerializer(serializers.HyperlinkedModelSerializer):
-    class Meta:
-        model = Terms
-        fields = ('uid', 'election_year', 'type', 'county', 'district', 'name', 'party', 'number', 'image')
 

--- a/candidates/views.py
+++ b/candidates/views.py
@@ -1,14 +1,16 @@
 from rest_framework import viewsets
 from .models import Terms
 from .serializers import CandidatesTermsSerializer
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Count, Q, F
 from boards.models import Boards
 from .filters import TermsFilter
 from app.filters import MaxResults
 
 class CandidatesTermsViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = Terms.objects.all().select_related('candidate').prefetch_related(Prefetch('boards', queryset=Boards.objects.order_by('-uploaded_at')))
+    queryset = Terms.objects.select_related('candidate') \
+    .prefetch_related(Prefetch('boards', queryset=Boards.objects.annotate(not_board_amount=Count('board_checks', filter=Q(board_checks__type=2, board_checks__is_board=False))).filter(not_board_amount__lte=2).order_by('-uploaded_at'))) \
+    .annotate(verified_board_amount=Count('boards', filter=Q(boards__verified_amount__gte=3)))
     serializer_class = CandidatesTermsSerializer
-    filter_fields = ('election_year', 'type', 'name', 'gender', 'party', 'constituency', 'county', 'district', 'votes', 'elected', 'occupy')
+    filter_fields = ('election_year', 'type', 'name', 'gender', 'party', 'constituency', 'county', 'district', 'votes', 'elected', 'occupy', 'verified_board_amount')
     filterset_class = TermsFilter
     pagination_class = MaxResults


### PR DESCRIPTION
## Route
`/api/candidates_terms`

## Changelog
`candidates_terms` could use `verified_amount` and `not_board_amount` to manipulate the embedded `boards` field.

There would be two extra fields returned for each `terms`: `verified_board_amount` and `unverified_board_amount`. The json template should be as follows:

```json
{
  "count": 0,
  "next": "string",
  "previous": "string",
  "results": [
    {
      "id": 0,
      "uid": "string",
      "election_year": "string",
      "type": "string",
      "county": "string",
      "district": "string",
      "name": "string",
      "party": "string",
      "number": 0,
      "image": "string",
      "boards": [
        {
          "image": "string",
          "coordinates": "string",
          "county": "string",
          "district": "string",
          "road": "string",
          "took_at": "2018-10-05T10:04:03.842Z",
          "uploaded_at": "2018-10-05T10:04:03.842Z",
          "uploaded_by": "string",
          "verified_amount": 0,
          "not_board_amount": 0
        }
      ],
      "constituency": 0,
      "verified_board_amount": 0,
      "unverified_board_amount": 0
    }
  ]
}
```

Given `verified_amount=2` and `not_board_amount=1` will set valid board criteria to not_board_amount <= 1.

`verified_board_amount` is the number of boards whose `verified_board_amount` >=2 among these boards. `unverified_board_amount` is the number of the rest boards. 

This fix #19