### PR TITLE
Fix the issue with verified_amount and not_board_amount

### DIFF
--- a/candidates/views.py
+++ b/candidates/views.py
@@ -7,9 +7,7 @@ from .filters import TermsFilter
 from app.filters import MaxResults
 
 class CandidatesTermsViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = Terms.objects.select_related('candidate') \
-    .prefetch_related(Prefetch('boards', queryset=Boards.objects.annotate(not_board_amount=Count('board_checks', filter=Q(board_checks__type=2, board_checks__is_board=False))).filter(not_board_amount__lte=2).order_by('-uploaded_at'))) \
-    .annotate(verified_board_amount=Count('boards', filter=Q(boards__verified_amount__gte=3)))
+    queryset = Terms.objects.select_related('candidate')
     serializer_class = CandidatesTermsSerializer
     filter_fields = ('election_year', 'type', 'name', 'gender', 'party', 'constituency', 'county', 'district', 'votes', 'elected', 'occupy', 'verified_board_amount')
     filterset_class = TermsFilter

--- a/election_boards/settings/local.py
+++ b/election_boards/settings/local.py
@@ -3,6 +3,27 @@ from .base import *
 SECRET_KEY = 'bWFuYWdlLnB55Yiw5bqV5piv5bm55Zib55qECg=='
 DEBUG = True
 
+LOGGING = {
+    'version': 1,
+    'filters': {
+        'require_debug_true': {
+            '()': 'django.utils.log.RequireDebugTrue',
+        }
+    },
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'filters': ['require_debug_true'],
+            'class': 'logging.StreamHandler',
+        }
+    },
+    'loggers': {
+        'django.db.backends': {
+            'level': 'DEBUG',
+            'handlers':['console'],
+        },
+    },
+}
 # # Configs for local with uwsgi
 # DEBUG = False
 # ALLOWED_HOSTS = ['*']


### PR DESCRIPTION
## Route 
`/api/candidates_terms`

## Changelog
1. In previous version, filter functions return queryset composed directly from Terms objects.
This would cause base filters, like `election_year` or `county` to be invalid. Now in the filter function I modified the queryset from previous filters. So the effect from base filters could be kept.

2. Fix "not returning queryset" issue in `verified_amount` filter
