### PR TITLE
Fix build failure caused by drone flow

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,6 @@ pipeline:
     - gcloud source repos clone default ../default
     - cp ../default/election-boards/dev/dev.py ./election_boards/settings/production.py
     - cp ../default/keystone/gcskeyfile.json ./app/gcskeyfile.json
-    - cp ../default/election-boards/*.conf .
     when:
       event: [push]
       branch: dev
@@ -35,6 +34,7 @@ pipeline:
     - cp ../default/election-boards/production/production.py ./election_boards/settings/production.py
     - cp ../default/election-boards/production/uwsgi.ini ./uwsgi.ini
     - cp ../default/election-boards/production/.kube.yml ./.kube.yml
+    - cp ../default/keystone/gcskeyfile.json ./app/gcskeyfile.json
     when:
       event: [push]
       branch: master


### PR DESCRIPTION
1. Removed copy supervisor conf for celery and celerybeat step.
2. Included service account token copy in production step.