### PR TITLE
Fix issue repetitive not_board_amount field

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -6,11 +6,13 @@ from google.oauth2 import service_account
 import googleapiclient.discovery
 
 from boards.models import Boards
+from django.conf import settings
 
 SCOPES = ['https://www.googleapis.com/auth/spreadsheets.readonly']
 SERVICE_ACCOUNT_FILE = 'app/gcskeyfile.json'
 
-SPREADSHEET_ID = '19UjwwLiQ_jfpzsjG_VKlNn1b3dGoFCs3ZOR4s7yGb0I'
+SPREADSHEET_ID = settings.SPREADSHEET_ID
+
 RANGE_NAME = '表單回應 1!A:K'
 
 @periodic_task(

--- a/boards/filters.py
+++ b/boards/filters.py
@@ -25,12 +25,12 @@ class BoardsFilter(filters.FilterSet):
         p = Point(float(m.group('lat')), float(m.group('lon')), srid=4326)
         # qs = Boards.objects.annotate(distance=Distance('coordinates', p)).filter(distance__lte=radius)
         return qs.filter(coordinates__distance_lte=(p,D(m=radius)))
-        
+ 
     def filter_not_board_amount(self, qs, name, value):
         if not value:
             return qs
-        
-        return qs.annotate(not_board_amount=Count('board_checks', filter=Q(board_checks__type=2, board_checks__is_board=False))).filter(not_board_amount__lte=value)
+ 
+        return qs.filter(not_board_amount__lte=value)
 
     class Meta:
         model = Boards

--- a/election_boards/settings/local.py
+++ b/election_boards/settings/local.py
@@ -2,6 +2,7 @@ from .base import *
 
 SECRET_KEY = 'bWFuYWdlLnB55Yiw5bqV5piv5bm55Zib55qECg=='
 DEBUG = True
+SPREADSHEET_ID = '19UjwwLiQ_jfpzsjG_VKlNn1b3dGoFCs3ZOR4s7yGb0I'
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
## Changelog
#### 1. Removed the annotation for `not_board_amount` in previous commits.
It's generated using annotation. But now we implemented a database field for it. So this annotation becomes unwanted and would throw an error when triggered.

#### 2. Adopted production version of spreadsheet on gcp.
In the previous version it only consumes the dev version of documents. In this PR I differentiated the source of spreadsheet between `dev` and `production`.