### PR TITLE
Added periodic tasks to back up database and upload to google cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 __pycache__
 election_boards/settings/dev.py
 election_boards/settings/production.py
-dumps
-*.dump
+dumps/*.dump
 # */migrations
 # migrations/*
 *.swp

--- a/election_boards/settings/local.py
+++ b/election_boards/settings/local.py
@@ -3,6 +3,7 @@ from .base import *
 SECRET_KEY = 'bWFuYWdlLnB55Yiw5bqV5piv5bm55Zib55qECg=='
 DEBUG = True
 SPREADSHEET_ID = '19UjwwLiQ_jfpzsjG_VKlNn1b3dGoFCs3ZOR4s7yGb0I'
+BACKUP_DB = False
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
## Changelog
In this PR, I included a celery task that will dump the entire database at denoted time, which is 3:30 in the morning. The naming will include the timestamp. Then this dump file will be uploaded to gcs, in the `dumps` folder in `projects` bucket.

After the uploading is completed, the dump file will be removed from local storage. In gcs, all the previous dump file will be kept.