### PR TITLE
feat(candidates): support inline for candidates

### DIFF
--- a/candidates/admin.py
+++ b/candidates/admin.py
@@ -10,7 +10,7 @@ class TermsInline(admin.StackedInline):
 @admin.register(Candidates)
 class CandidatesAdmin(admin.ModelAdmin):
     search_fields = ('name',)
-    # inlines = (TermsInline,)
+    inlines = (TermsInline,)
 
 # Register your models here.
 @admin.register(Terms)

--- a/candidates/models.py
+++ b/candidates/models.py
@@ -25,6 +25,14 @@ class Candidates(models.Model):
 
     def __str__(self):
         return self.name
+    
+    def save(self, *args, **kwargs):
+        """Set uid to uuid ver.4 if it's not set. This is for inline form when using admin"""
+        
+        if self.uid is None:
+            self.uid = uuid.uuid4()
+
+        super(Candidates, self).save(*args, **kwargs)
 
 class Terms(models.Model):
     


### PR DESCRIPTION
For now use `save()` method in `Candidates` model to fix the problem default not set in admin when inline of `Terms` is enabled.