### PR TITLE
fix(boards): saved not_board_amount directly with Boards queryset

### DIFF
--- a/boards/serializers.py
+++ b/boards/serializers.py
@@ -117,6 +117,7 @@ class SingleCheckDeserializer(serializers.ModelSerializer):
         return check
 
 class MultiChecksDeserializer(serializers.Serializer):
+    """Convert input when validate multiple boards"""
     is_board = serializers.ListField(
         child = serializers.PrimaryKeyRelatedField(queryset=Boards.objects.all())
     )
@@ -143,9 +144,10 @@ class MultiChecksDeserializer(serializers.Serializer):
                 check = Checks(**{'board':board, 'is_board': False, 'created_by': created_by, 'type': 2, 'is_original': False})
                 check.save()
 
-                ib = Boards.objects.get(pk=board)
-                ib.not_board_amount += 1
-                ib.save()
+                # ib = Boards.objects.get(pk=board)
+                board.not_board_amount += 1
+                board.save()
+                
         return validated_data
 
 class SingleCheckSerializer(serializers.ModelSerializer):

--- a/boards/urls.py
+++ b/boards/urls.py
@@ -9,5 +9,4 @@ urlpatterns = [
     path('verify/board', SingleCheckViewSet.as_view({'get':'list', 'post':'create'})),
     path('verify/board/<int:pk>', SingleCheckViewSet.as_view({'get':'retrieve'})),
     path('verify/boards', MultiChecksViewSet.as_view({'post':'create'})),
-    
 ]


### PR DESCRIPTION
Previously I used `ib = Boards.objects.get(pk=board)` to get the correct board object, add the `not_board_amount` then `save()`. But in the deserializer has already return `Boards` for me, which I could exploit directly to update the `not_board_amount` field. In this pull request, I change to use what deserializer returned and abolished the primary-key method.