### PR TITLE
New filter, validate rules, and bug fixes

### DIFF
--- a/boards/filters.py
+++ b/boards/filters.py
@@ -14,6 +14,7 @@ class BoardsFilter(filters.FilterSet):
     not_board_amount = filters.NumberFilter(method='filter_not_board_amount')
     coordinates = filters.CharFilter(method='filter_coordinates')
     candidates = filters.ModelChoiceFilter(queryset=Terms.objects.all())
+    election_year = filters.CharFilter(field_name='candidates__election_year', lookup_expr='exact')
 
     def filter_coordinates(self, qs, name, value):
         if not value:

--- a/boards/serializers.py
+++ b/boards/serializers.py
@@ -117,6 +117,7 @@ class SingleCheckDeserializer(serializers.ModelSerializer):
         return check
 
 class MultiChecksDeserializer(serializers.Serializer):
+    """Convert input when validate multiple boards"""
     is_board = serializers.ListField(
         child = serializers.PrimaryKeyRelatedField(queryset=Boards.objects.all())
     )
@@ -143,9 +144,10 @@ class MultiChecksDeserializer(serializers.Serializer):
                 check = Checks(**{'board':board, 'is_board': False, 'created_by': created_by, 'type': 2, 'is_original': False})
                 check.save()
 
-                ib = Boards.objects.get(pk=board)
-                ib.not_board_amount += 1
-                ib.save()
+                # ib = Boards.objects.get(pk=board)
+                board.not_board_amount += 1
+                board.save()
+                
         return validated_data
 
 class SingleCheckSerializer(serializers.ModelSerializer):

--- a/boards/serializers.py
+++ b/boards/serializers.py
@@ -99,10 +99,12 @@ class SingleCheckDeserializer(serializers.ModelSerializer):
 
         if headcount_max is None:
             headcount_max = Checks.objects.filter(board=validated_data['board'], is_original=True).only('headcount')[0].headcount
-        # Select 'headcount_max' most frequent candidates in check
+        # Count how many times a board is identified belonging to a candidates.
+        # If the counts equals, sort them with created_at
+        # The original answer is counted as a verification
         most_candidates = [p['candidates__id'] for p in Checks.objects.filter(board=validated_data['board']) \
-            .values('candidates__id').annotate(hcm=Count('candidates__id')).order_by('-hcm') \
-            if p['candidates__id'] is not None and p['hcm'] != 0]
+            .values('candidates__id').annotate(verify_frequency=Count('candidates__id'), last_update=Max('created_at')).order_by('-verify_frequency','-last_update') \
+            if p['candidates__id'] is not None and p['verify_frequency'] != 0]
 
         if headcount_max > 0:
             if len(most_candidates) > headcount_max:

--- a/boards/urls.py
+++ b/boards/urls.py
@@ -5,7 +5,7 @@ app_name = 'boards'
 
 urlpatterns = [
     path('boards/gongdebook', gongde_list),
-    path('boards/', MultiBoardsViewSet.as_view({'get':'list', 'post':'create'})),
+    path('boards', MultiBoardsViewSet.as_view({'get':'list', 'post':'create'})),
     path('verify/board', SingleCheckViewSet.as_view({'get':'list', 'post':'create'})),
     path('verify/board/<int:pk>', SingleCheckViewSet.as_view({'get':'retrieve'})),
     path('verify/boards', MultiChecksViewSet.as_view({'post':'create'})),

--- a/boards/urls.py
+++ b/boards/urls.py
@@ -9,5 +9,4 @@ urlpatterns = [
     path('verify/board', SingleCheckViewSet.as_view({'get':'list', 'post':'create'})),
     path('verify/board/<int:pk>', SingleCheckViewSet.as_view({'get':'retrieve'})),
     path('verify/boards', MultiChecksViewSet.as_view({'post':'create'})),
-    
 ]

--- a/candidates/admin.py
+++ b/candidates/admin.py
@@ -10,7 +10,7 @@ class TermsInline(admin.StackedInline):
 @admin.register(Candidates)
 class CandidatesAdmin(admin.ModelAdmin):
     search_fields = ('name',)
-    # inlines = (TermsInline,)
+    inlines = (TermsInline,)
 
 # Register your models here.
 @admin.register(Terms)

--- a/candidates/models.py
+++ b/candidates/models.py
@@ -25,6 +25,14 @@ class Candidates(models.Model):
 
     def __str__(self):
         return self.name
+    
+    def save(self, *args, **kwargs):
+        """Set uid to uuid ver.4 if it's not set. This is for inline form when using admin"""
+        
+        if self.uid is None:
+            self.uid = uuid.uuid4()
+
+        super(Candidates, self).save(*args, **kwargs)
 
 class Terms(models.Model):
     

--- a/election_boards/settings/local.py
+++ b/election_boards/settings/local.py
@@ -26,6 +26,10 @@ LOGGING = {
         },
     },
 }
+
+USE_X_FORWARDED_HOST = True
+FORCE_SCRIPT_NAME = '/project/election-boards'
+
 # # Configs for local with uwsgi
 # DEBUG = False
 # ALLOWED_HOSTS = ['*']

--- a/election_boards/urls.py
+++ b/election_boards/urls.py
@@ -26,7 +26,7 @@ from drf_yasg import openapi
 from django.conf import settings
 from django.contrib.auth import logout
 
-router = routers.DefaultRouter()
+router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'candidates_terms', CandidatesTermsViewSet)
 router.register(r'councilors_terms', CouncilorsDetailViewSet)
 router.register(r'elections', ElectionsViewSet)


### PR DESCRIPTION
## Changelog

### Features
#### Included `election_year` filter
```bash
?election_year=[YEAR_STRING]
```
This fix #67 

Use above query parameter to filter `election_year`

#### Ordered boards equally verified by descending created_at
The information filled in the beginning are **counted** as one verification.

#### Supported inline Terms form in Candidates
Now it's possible to create new `Candidates` and their `Terms` at the same time.

### Bug fixes
#### disabled appended slash
To fix the extra `SCRIPT_NAME` prepend issue when redirect. 

#### Use deserializer return values to update `Checks`
This fix #73 

